### PR TITLE
feat: Enable dark mode toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import { GeistMono } from 'geist/font/mono'
 
 import '@/app/globals.css'
 import { cn } from '@/lib/utils'
-// import { ThemeToggle } from '@/components/theme-toggle'
+import { ThemeToggle } from '@/components/theme-toggle'
 import { Providers } from '@/components/providers'
 import { Header } from '@/components/header'
 import { Toaster } from '@/components/ui/sonner'
@@ -57,7 +57,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
             <Header />
             <main className="flex flex-col flex-1 bg-muted/50">{children}</main>
           </div>
-          {/* <ThemeToggle /> */}
+          <ThemeToggle />
         </Providers>
       </body>
     </html>


### PR DESCRIPTION
The project was already configured with `next-themes` and Tailwind CSS for dark mode support, including CSS variables for both themes.

This change enables the existing `ThemeToggle` component in the main layout (`app/layout.tsx`), allowing you to switch between light and dark themes.

Theme persistence via local storage and respecting system preferences are handled automatically by the `next-themes` library configuration.