### PR TITLE
feat: Add persistent chat history using localStorage

### DIFF
--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -1,6 +1,6 @@
 import { nanoid } from '@/lib/utils'
 import { Chat } from '@/components/chat'
-import { AI } from '@/lib/chat/actions'
+import { ChatProviderWrapper } from '@/components/chat-provider-wrapper'
 import { Session } from '@/lib/types'
 import { getMissingKeys } from '@/app/actions'
 
@@ -13,8 +13,8 @@ export default async function IndexPage() {
   const missingKeys = await getMissingKeys()
 
   return (
-    <AI initialAIState={{ chatId: id, messages: [] }}>
+    <ChatProviderWrapper chatId={id}>
       <Chat id={id} missingKeys={missingKeys} />
-    </AI>
+    </ChatProviderWrapper>
   )
 }

--- a/components/chat-provider-wrapper.tsx
+++ b/components/chat-provider-wrapper.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import React, { useEffect, useState, ReactNode } from 'react'
+import { AI } from '@/lib/chat/actions'
+import { useLocalStorage } from '@/lib/hooks/use-local-storage'
+import { Message } from '@/lib/types'
+
+interface ChatProviderWrapperProps {
+  chatId: string
+  children: ReactNode
+}
+
+export function ChatProviderWrapper({ chatId, children }: ChatProviderWrapperProps) {
+  const [storedMessages, setStoredMessages] = useLocalStorage<Message[]>(
+    'chat_' + chatId,
+    []
+  )
+  const [isLoaded, setIsLoaded] = useState(false)
+
+  useEffect(() => {
+    // Set isLoaded to true only on the client side after initial mount/hydration
+    setIsLoaded(true)
+  }, []) // Empty dependency array ensures this runs only once after mount
+
+  if (!isLoaded) {
+    // Return null or a loading indicator during SSR or before hydration is complete
+    // This prevents rendering the AI provider with potentially incorrect initial state
+    return null
+  }
+
+  return (
+    <AI initialAIState={{ chatId: chatId, messages: storedMessages }}>
+      {children}
+    </AI>
+  )
+}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -28,7 +28,9 @@ export function Chat({ id, className, session, missingKeys }: ChatProps) {
   const [messages] = useUIState()
   const [aiState] = useAIState()
 
-  const [_, setNewChatId] = useLocalStorage('newChatId', id)
+  // Get the setter function for saving messages to local storage
+  const [_, saveMessages] = useLocalStorage<Message[]>('chat_' + id, [])
+  const [__, setNewChatId] = useLocalStorage('newChatId', id) // Keep existing newChatId logic
 
   useEffect(() => {
     if (session?.user) {
@@ -45,6 +47,15 @@ export function Chat({ id, className, session, missingKeys }: ChatProps) {
     }
     console.log('Value: ', aiState.messages)
   }, [aiState.messages, router])
+
+  // Save messages to local storage whenever they change, but only if not empty
+  useEffect(() => {
+    // Check if aiState and messages exist and the messages array is not empty
+    if (aiState?.messages && aiState.messages.length > 0) {
+       saveMessages(aiState.messages)
+    }
+    // Do not save if messages are empty to avoid overwriting initial state or clearing storage unnecessarily
+  }, [aiState.messages, saveMessages, id]) // Dependencies include messages, the save function, and the chat ID
 
   useEffect(() => {
     setNewChatId(id)


### PR DESCRIPTION
Implements persistent chat history by leveraging the browser's localStorage.

Key changes:
- Created `ChatProviderWrapper`, a client component that uses the `useLocalStorage` hook to load chat messages associated with a specific chat ID before initializing the AI state.
- Modified `app/(chat)/page.tsx` to use `ChatProviderWrapper` instead of directly initializing the `AI` provider, ensuring history is loaded client-side.
- Updated `components/chat.tsx` to use `useEffect` and `useLocalStorage` to automatically save the `aiState.messages` to localStorage whenever they change.

This allows you to reload the page or close and reopen the browser without losing your current chat conversation.