### PR TITLE
refactor: Implement persistent chat history via server action

### DIFF
--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -1,6 +1,6 @@
 import { nanoid } from '@/lib/utils'
 import { Chat } from '@/components/chat'
-import { ChatProviderWrapper } from '@/components/chat-provider-wrapper'
+import { AI } from '@/lib/chat/actions'
 import { Session } from '@/lib/types'
 import { getMissingKeys } from '@/app/actions'
 
@@ -13,8 +13,8 @@ export default async function IndexPage() {
   const missingKeys = await getMissingKeys()
 
   return (
-    <ChatProviderWrapper chatId={id}>
+    <AI initialAIState={{ chatId: id, messages: [] }}>
       <Chat id={id} missingKeys={missingKeys} />
-    </ChatProviderWrapper>
+    </AI>
   )
 }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -5,8 +5,8 @@ import { ChatList } from '@/components/chat-list'
 import { ChatPanel } from '@/components/chat-panel'
 import { EmptyScreen } from '@/components/empty-screen'
 import { useLocalStorage } from '@/lib/hooks/use-local-storage'
-import { useEffect, useState } from 'react'
-import { useUIState, useAIState } from 'ai/rsc'
+import { useEffect, useState, useRef } from 'react' // Added useRef
+import { useUIState, useAIState, useActions } from 'ai/rsc' // Added useActions
 import { Message, Session } from '@/lib/types'
 import { usePathname, useRouter } from 'next/navigation'
 import { useScrollAnchor } from '@/lib/hooks/use-scroll-anchor'
@@ -24,17 +24,71 @@ export interface ChatProps extends React.ComponentProps<'div'> {
 export function Chat({ id, className, session, missingKeys }: ChatProps) {
   const router = useRouter()
   const path = usePathname()
+  // Removed duplicate router/path declarations
   const [input, setInput] = useState('')
-  const [messages] = useUIState()
-  const [aiState] = useAIState()
 
-  // Get the setter function for saving messages to local storage
-  const [_, saveMessages] = useLocalStorage<Message[]>('chat_' + id, [])
-  const [__, setNewChatId] = useLocalStorage('newChatId', id) // Keep existing newChatId logic
+  // State Hooks
+  const [messages, setMessages] = useUIState()
+  const [aiState, setAIState] = useAIState() // Keep setAIState for other potential uses if needed
+  const { restoreChatHistory } = useActions() // Get the action
+  const [_, saveMessages] = useLocalStorage<Message[]>('chat_' + id, []) // Keep useLocalStorage primarily for saving
+  const [isLoadingFromStorage, setIsLoadingFromStorage] = useState(true)
+  const aiStateRef = useRef(aiState) // Ref for latest AI state in initial effect
+  const [___, setNewChatId] = useLocalStorage('newChatId', id) // Keep existing newChatId logic
 
+  // Effect to keep AI state ref updated (Keep this)
+  useEffect(() => {
+    aiStateRef.current = aiState
+  }, [aiState])
+
+  // Effect to load messages from local storage on initial mount
+  useEffect(() => {
+    if (isLoadingFromStorage && id) {
+      console.log('Attempting to load messages from localStorage for chat:', id)
+      const storedMessagesJson = localStorage.getItem('chat_' + id)
+      let parsedMessages: Message[] | null = null
+
+      if (storedMessagesJson) {
+        try {
+          parsedMessages = JSON.parse(storedMessagesJson)
+          console.log('Parsed messages from storage:', parsedMessages)
+        } catch (error) {
+          console.error('Failed to parse messages from localStorage:', error)
+          // Optionally clear invalid storage item: localStorage.removeItem('chat_' + id);
+        }
+      }
+
+      // Use ref to get the latest messages length, even if aiState isn't updated yet
+      const currentMessagesLength = aiStateRef.current?.messages?.length ?? 0
+      console.log('Current AI state messages length (via ref):', currentMessagesLength)
+
+      if (parsedMessages && parsedMessages.length > 0 && currentMessagesLength === 0) {
+        console.log('Restoring chat history from storage using action.')
+        // Use the action to restore history instead of directly setting state
+        restoreChatHistory(parsedMessages)
+      } else {
+        console.log('Skipping history restoration (no stored messages, storage invalid, or AI state already populated).')
+      }
+      setIsLoadingFromStorage(false) // Mark loading as complete
+    }
+    // Dependencies: id, isLoadingFromStorage, and the restoreChatHistory action
+  }, [id, isLoadingFromStorage, restoreChatHistory]) // Updated dependencies
+
+  // Effect to save messages to local storage when AI state changes
+  useEffect(() => {
+    // Only save if loading from storage is complete to avoid overwriting loaded state
+    if (!isLoadingFromStorage && id) {
+      console.log('Saving messages to storage:', aiState.messages)
+      saveMessages(aiState.messages ?? []) // Save current AI state messages using the hook's setter
+    }
+    // Dependencies: AI messages, the save function, id, and loading flag
+  }, [aiState.messages, saveMessages, id, isLoadingFromStorage])
+
+
+  // Existing Effects (keep)
   useEffect(() => {
     if (session?.user) {
-      if (!path.includes('chat') && messages.length === 1) {
+      if (!path.includes('chat') && messages.length === 1) { // Use UI messages here for URL update logic
         window.history.replaceState({}, '', `/chat/${id}`)
       }
     }
@@ -45,18 +99,10 @@ export function Chat({ id, className, session, missingKeys }: ChatProps) {
     if (messagesLength === 2) {
       router.refresh()
     }
-    console.log('Value: ', aiState.messages)
-  }, [aiState.messages, router])
+    console.log('Current AI State Value: ', aiState.messages) // Keep for debugging
+  }, [aiState.messages, router]) // Keep this effect
 
-  // Save messages to local storage whenever they change, but only if not empty
-  useEffect(() => {
-    // Check if aiState and messages exist and the messages array is not empty
-    if (aiState?.messages && aiState.messages.length > 0) {
-       saveMessages(aiState.messages)
-    }
-    // Do not save if messages are empty to avoid overwriting initial state or clearing storage unnecessarily
-  }, [aiState.messages, saveMessages, id]) // Dependencies include messages, the save function, and the chat ID
-
+  // Keep this effect
   useEffect(() => {
     setNewChatId(id)
   })

--- a/lib/chat/actions.tsx
+++ b/lib/chat/actions.tsx
@@ -166,6 +166,22 @@ Besides the symbol, you cannot customize any of the screeners or graphics. Do no
   }
 }
 
+async function restoreChatHistory(messages: Message[]) {
+  'use server'
+
+  const aiState = getMutableAIState<typeof AI>()
+
+  // Update the AI state with the provided messages, replacing the existing ones.
+  // Ensure the chatId is preserved.
+  aiState.update({
+    chatId: aiState.get().chatId, // Keep the existing chatId
+    messages: messages           // Replace the messages array
+  })
+
+  // No UI update is needed here as this action primarily updates the AI state.
+  // The UI should react based on changes to the AI state.
+}
+
 async function submitUserMessage(content: string) {
   'use server'
 
@@ -840,7 +856,8 @@ Assistant (you): { "tool_call": { "id": "pending", "type": "function", "function
 
 export const AI = createAI<AIState, UIState>({
   actions: {
-    submitUserMessage
+    submitUserMessage,
+    restoreChatHistory // Add the new action here
   },
   initialUIState: [],
   initialAIState: { chatId: nanoid(), messages: [] }


### PR DESCRIPTION
Refactors the persistent chat history feature to resolve server/client component conflicts.

Key changes:
- `app/(chat)/page.tsx` remains a Server Component, initializing the `AI` provider.
- Added a new server action `restoreChatHistory` to `lib/chat/actions.tsx` specifically for updating the AI message state from the client.
- Modified `components/chat.tsx` (client component):
    - Uses `localStorage` to store/retrieve messages.
    - On mount, calls the `restoreChatHistory` action if localStorage contains messages and the initial AI state is empty.
    - Saves message updates from `aiState` back to `localStorage`.
- Removed the `ChatProviderWrapper` component used in the previous approach.

This approach keeps server actions within the server context while allowing client components to interact with `localStorage` and trigger state updates via dedicated actions. You need to run `pnpm install` separately to update the lockfile.